### PR TITLE
Fix wrong Firebase storage bucket URL

### DIFF
--- a/firebase-config.js
+++ b/firebase-config.js
@@ -2,7 +2,7 @@ const firebaseConfig = {
     apiKey: "AIzaSyBeAVHfvUU993JQHJLMc9BHsV2KUZOs33U",
     authDomain: "my-list-2f3a7.firebaseapp.com",
     projectId: "my-list-2f3a7",
-    storageBucket: "my-list-2f3a7.firebasestorage.app",
+    storageBucket: "my-list-2f3a7.appspot.com",
     messagingSenderId: "515380103480",
     appId: "1:515380103480:web:0d6c2e7d4ee47cc9d299cd",
     measurementId: "G-V0K1T22ZNB"


### PR DESCRIPTION
## Summary
- correct firebase storage bucket domain in firebase-config.js

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68402d100608832588e0b0f4e9ce1b63