### PR TITLE
Improve local storage handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,6 @@ Este é um sistema web interativo projetado para ajudar usuários a catalogar e 
 ## Evolução do Projeto
 
 Este sistema evoluiu de uma versão inicial que utilizava o `localStorage` do navegador para armazenamento de dados para uma solução mais robusta e escalável, utilizando o Firebase para oferecer persistência na nuvem, autenticação segura e funcionalidades multiusuário.
+## Melhorias Recentes
+- Geração de IDs agora utiliza `crypto.randomUUID()` quando disponível, aumentando a segurança.
+- Operações em modo localStorage evitam recarregar todo o conjunto de itens, reduzindo leituras.

--- a/script-app.js
+++ b/script-app.js
@@ -203,6 +203,9 @@ document.addEventListener('DOMContentLoaded', () => {
      * @returns {string} ID único.
      */
     function generateId() {
+        if (window.crypto && window.crypto.randomUUID) {
+            return window.crypto.randomUUID();
+        }
         return '_' + Math.random().toString(36).substr(2, 9) + Date.now().toString(36);
     }
 
@@ -567,9 +570,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     await activeDataManager.addItem(currentUser.uid, dataForFirebase); 
                     // O listener onSnapshot do Firebase atualizará a UI automaticamente
                 } else { // Modo LocalStorage
-                    activeDataManager.addItem(newItemData, items); // 'items' é modificado por referência
-                    items = activeDataManager.loadItems(); // Recarrega 'items' para garantir consistência com IDs
-                    renderAppUI(); // Re-renderiza manualmente para LocalStorage
+                activeDataManager.addItem(newItemData, items); // 'items' modificado por referência
+                renderAppUI(); // Re-renderiza manualmente para LocalStorage
                 }
                 // Limpa o formulário e reseta as estrelas
                 itemForm.reset(); 
@@ -606,8 +608,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (modoOperacao === 'firebase' && currentUser) { 
                 await activeDataManager.updateItem(itemId, updatedData); // onSnapshot do Firebase cuida da UI
             } else { // Modo LocalStorage
-                activeDataManager.updateItem(itemId, updatedData, items); 
-                items = activeDataManager.loadItems(); // Recarrega 'items'
+                activeDataManager.updateItem(itemId, updatedData, items);
                 renderAppUI(); // Re-renderiza para LocalStorage
             }
             editingItemId = null; 


### PR DESCRIPTION
## Summary
- avoid unnecessary localStorage reloads
- use `crypto.randomUUID` for safer IDs
- document recent improvements

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68502d86ede48325942f5ecada70e0ad