### PR TITLE
Remove lingering alerts

### DIFF
--- a/script-app.js
+++ b/script-app.js
@@ -608,19 +608,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
         try {
             editingItemId = null; // Define como null antes de atualizar para evitar re-renderização em modo edição
-            alert('Categoria, Marca/Modelo e Nome do Produto não podem ficar vazios.'); return;
-        }
-
-        try {
             if (modoOperacao === 'firebase' && currentUser) {
                 await activeDataManager.updateItem(itemId, updatedData); // onSnapshot do Firebase cuida da UI
-                editingItemId = null;
-                alert('Alterações salvas com sucesso!');
             } else { // Modo LocalStorage
-                editingItemId = null;
                 activeDataManager.updateItem(itemId, updatedData, items);
                 renderAppUI(); // Re-renderiza para LocalStorage
-                alert('Alterações salvas com sucesso!');
             }
             showInfoModal('Alterações salvas com sucesso!', true);
             // renderItems(); // Não é estritamente necessário se renderAppUI é chamado ou onSnapshot está ativo
@@ -628,9 +620,6 @@ document.addEventListener('DOMContentLoaded', () => {
             console.error("Erro ao atualizar item:", error);
             showInfoModal("Erro ao atualizar item.");
             // renderItems(); // Não é estritamente necessário se renderAppUI é chamado ou onSnapshot está ativo
-        } catch (error) {
-            console.error("Erro ao atualizar item:", error);
-            alert("Erro ao atualizar item.");
         }
     }
     


### PR DESCRIPTION
## Summary
- clean up `saveEditedItem` to rely solely on modal notifications

## Testing
- `npm test` *(fails: no test specified)*
- `npm start`
- `node --check script-app.js`


------
https://chatgpt.com/codex/tasks/task_e_68503fca080883258d3f5c766b4c99f0