### PR TITLE
Implement list management

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,12 @@ Este sistema evoluiu de uma versão inicial que utilizava o `localStorage` do na
 2. Cada documento deve conter os campos `ownerId`, `invitedEmail` e `permission` (`read` ou `write`).
 3. Ajuste as regras de segurança para permitir leitura de itens quando houver um documento em `sharedLists` que relacione o email logado com o `ownerId` do item.
 4. Para escrita, as regras devem também verificar se o usuário convidado possui `isPremium: true` em `userProfiles`.
+
+### Passos para habilitar Listas Múltiplas
+
+1. Crie uma nova coleção chamada `lists` no Firestore.
+2. Cada documento deve conter `ownerId`, `name`, `createdAt` e `updatedAt`.
+3. Adicione o campo `listId` em todos os documentos da coleção `items`, apontando para o ID da lista correspondente.
+4. Inclua também `listId` nos documentos de `sharedLists` para que o compartilhamento seja feito por lista.
+5. Atualize suas regras de segurança seguindo o arquivo `firestore.rules` deste repositório.
+6. Para itens existentes, crie manualmente uma lista (por exemplo, "Principal") e atualize cada item com o `listId` dessa lista.

--- a/app.html
+++ b/app.html
@@ -113,17 +113,47 @@
       </div>
 
       <div id="app-content" style="display: none">
-        <div class="container">
+        <section id="lists-section">
+          <div class="container">
+            <header class="list-header">
+              <h1><i class="fas fa-list"></i> Minhas Listas</h1>
+              <div class="controls">
+                <button id="theme-toggle-lists" class="theme-toggle" aria-label="Alternar Tema">
+                  <i class="fas fa-moon"></i>
+                </button>
+                <button id="create-list"><i class="fas fa-plus"></i> Criar Lista</button>
+              </div>
+            </header>
+            <div class="table-wrapper">
+              <table id="lists-table">
+                <thead>
+                  <tr>
+                    <th>Nome</th>
+                    <th>Criada em</th>
+                    <th>Atualizada em</th>
+                    <th>Dono</th>
+                    <th>Ações</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+
+        <section id="items-section" style="display: none">
+          <div class="container">
           <header>
-            <div class="header-left">
-              <h1>
-                <i class="fas fa-list-check"></i> Minha Lista
-                <span id="mode-indicator"></span>
-              </h1>
+              <div class="header-left">
+                <h1>
+                  <i class="fas fa-list-check"></i>
+                  <span id="list-name" contenteditable="true">Minha Lista</span>
+                  <span id="mode-indicator"></span>
+                </h1>
               <span id="user-email-display" class="user-email"></span>
             </div>
             <div class="controls">
-              <button id="theme-toggle" aria-label="Alternar Tema">
+              <button id="theme-toggle" class="theme-toggle" aria-label="Alternar Tema">
                 <i class="fas fa-moon"></i>
               </button>
               <button id="export-data">
@@ -138,9 +168,12 @@
                 accept=".json"
                 style="display: none"
               />
-              <button id="share-list" style="display: none">
-                <i class="fas fa-share-alt"></i> Compartilhar Lista
-              </button>
+                <button id="share-list" style="display: none">
+                  <i class="fas fa-share-alt"></i> Compartilhar Lista
+                </button>
+                <button id="back-to-lists" style="display: none">
+                  <i class="fas fa-list"></i> Listas
+                </button>
               <button
                 id="upgrade-to-premium"
                 style="display: none"
@@ -236,8 +269,8 @@
             </div>
           </div>
         </div>
+        </section>
       </div>
-    </div>
 
     <div id="share-modal" class="modal">
       <div class="modal-content">
@@ -270,6 +303,22 @@
             >
               Salvar
             </button>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <div id="create-list-modal" class="modal">
+      <div class="modal-content">
+        <h2><i class="fas fa-plus"></i> Nova Lista</h2>
+        <form id="create-list-form">
+          <div class="form-group">
+            <label for="new-list-name">Nome:</label>
+            <input type="text" id="new-list-name" required />
+          </div>
+          <div class="modal-buttons">
+            <button type="button" id="create-list-cancel" class="btn-cancel">Cancelar</button>
+            <button type="submit" id="create-list-save" class="btn-confirm positive-action">Salvar</button>
           </div>
         </form>
       </div>

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,11 +2,16 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     match /items/{itemId} {
-      allow read, write: if request.auth != null && request.auth.uid == resource.data.userId;
-      allow create: if request.auth != null && request.auth.uid == request.resource.data.userId
+      allow read, write: if request.auth != null
+        && request.auth.uid == resource.data.userId
+        && resource.data.userId == get(/databases/$(database)/documents/lists/$(resource.data.listId)).data.ownerId;
+      allow create: if request.auth != null
+        && request.auth.uid == request.resource.data.userId
+        && get(/databases/$(database)/documents/lists/$(request.resource.data.listId)).data.ownerId == request.auth.uid
         && request.resource.data.name is string
         && request.resource.data.brand is string
         && request.resource.data.category is string
+        && request.resource.data.listId is string
         && request.resource.data.rating is number
         && request.resource.data.name.size() > 0 && request.resource.data.name.size() <= 200
         && request.resource.data.brand.size() > 0 && request.resource.data.brand.size() <= 100
@@ -25,8 +30,16 @@ service cloud.firestore {
     match /sharedLists/{shareId} {
       allow create: if request.auth != null && request.auth.uid == request.resource.data.ownerId
         && request.resource.data.invitedEmail is string
-        && request.resource.data.permission in ['read', 'write'];
+        && request.resource.data.permission in ['read', 'write']
+        && request.resource.data.listId is string;
       allow read, write: if request.auth != null && request.auth.uid == resource.data.ownerId;
+    }
+
+    match /lists/{listId} {
+      allow read, write: if request.auth != null && request.auth.uid == resource.data.ownerId;
+      allow create: if request.auth != null && request.auth.uid == request.resource.data.ownerId
+        && request.resource.data.name is string
+        && request.resource.data.name.size() > 0 && request.resource.data.name.size() <= 100;
     }
   }
 }

--- a/script-app.js
+++ b/script-app.js
@@ -72,13 +72,24 @@ document.addEventListener('DOMContentLoaded', () => {
     const hiddenRatingInput = document.getElementById('item-rating-hidden');
     const currentRatingDisplay = document.getElementById('current-rating-display');
 
-    // Tabela e Abas de Itens
+    // Seções e Tabelas
+    const listsSection = document.getElementById('lists-section');
+    const itemsSection = document.getElementById('items-section');
+    const listsTableBody = document.querySelector('#lists-table tbody');
+    const createListButton = document.getElementById('create-list');
+    const createListModal = document.getElementById('create-list-modal');
+    const createListForm = document.getElementById('create-list-form');
+    const newListNameInput = document.getElementById('new-list-name');
+    const createListCancel = document.getElementById('create-list-cancel');
+    const backToListsButton = document.getElementById('back-to-lists');
+    const listNameDisplay = document.getElementById('list-name');
+
     const itemsTableBody = document.querySelector('#items-table tbody');
     const categoryTabsContainer = document.getElementById('category-tabs-container');
 
     // Controles Gerais e Modal
-    const themeToggleButton = document.getElementById('theme-toggle');
-    let themeToggleIcon = themeToggleButton ? themeToggleButton.querySelector('i') : null;
+    const themeToggleButtons = document.querySelectorAll('.theme-toggle');
+    let themeToggleIcons = Array.from(themeToggleButtons).map(btn => btn.querySelector('i'));
     const exportButton = document.getElementById('export-data');
     const importFileInput = document.getElementById('import-file');
     const deleteCategoryButton = document.getElementById('delete-category');
@@ -96,6 +107,8 @@ document.addEventListener('DOMContentLoaded', () => {
     // ---------------------------------------------------------------------------
     // ESTADO GLOBAL DA APLICAÇÃO
     // ---------------------------------------------------------------------------
+    let lists = [];                                 // Array para armazenar as listas
+    let activeListId = null;                        // ID da lista atualmente em edição
     let items = [];                                 // Array para armazenar os itens da lista
     let editingItemId = null;                       // ID do item atualmente em edição, ou null
     let actionToConfirm = null;                     // Função a ser executada após confirmação no modal
@@ -109,7 +122,8 @@ document.addEventListener('DOMContentLoaded', () => {
     let unsubscribePrefsListener = () => {};        // Listener para atualizações da coleção 'userProfiles'
 
     // Chaves para o LocalStorage (versionadas para evitar conflitos com dados antigos)
-    const LOCAL_STORAGE_ITEMS_KEY = 'appItemsLocal_v3_freemium_final'; 
+    const LOCAL_STORAGE_LISTS_KEY = 'appListsLocal_v1';
+    const LOCAL_STORAGE_ITEMS_KEY = 'appItemsLocal_v3_freemium_final';
     const LOCAL_STORAGE_THEME_KEY = 'appThemeLocal_v3_freemium_final';
 
     // ---------------------------------------------------------------------------
@@ -161,6 +175,26 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     };
 
+    const lsListManager = {
+        loadLists: () => {
+            const stored = localStorage.getItem(LOCAL_STORAGE_LISTS_KEY);
+            try {
+                return stored ? JSON.parse(stored) : [];
+            } catch (e) {
+                console.error('Erro ao carregar listas do LocalStorage:', e);
+                localStorage.removeItem(LOCAL_STORAGE_LISTS_KEY);
+                return [];
+            }
+        },
+        saveLists: (currentLists) => {
+            try {
+                localStorage.setItem(LOCAL_STORAGE_LISTS_KEY, JSON.stringify(currentLists));
+            } catch (e) {
+                console.error('Erro ao salvar listas no LocalStorage:', e);
+            }
+        }
+    };
+
     /**
      * Gerenciador de dados para Firebase Firestore (modo premium).
      */
@@ -199,7 +233,50 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     };
 
+    const fbListManager = {
+        loadLists: async (userId) => {
+            try {
+                const snapshot = await db.collection('lists')
+                                     .where('ownerId', '==', userId)
+                                     .orderBy('createdAt', 'desc')
+                                     .get();
+                return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+            } catch (e) {
+                console.error('Erro ao carregar listas do Firestore:', e);
+                return [];
+            }
+        },
+        addList: async (userId, name) => {
+            const data = {
+                ownerId: userId,
+                name,
+                createdAt: firebase.firestore.FieldValue.serverTimestamp(),
+                updatedAt: firebase.firestore.FieldValue.serverTimestamp()
+            };
+            const docRef = await db.collection('lists').add(data);
+            return { id: docRef.id, ...data };
+        },
+        updateList: async (listId, data) => {
+            await db.collection('lists').doc(listId).update({
+                ...data,
+                updatedAt: firebase.firestore.FieldValue.serverTimestamp()
+            });
+        },
+        deleteList: async (listId) => {
+            await db.collection('lists').doc(listId).delete();
+            const itemsSnap = await db.collection('items').where('listId', '==', listId).get();
+            const batch = db.batch();
+            itemsSnap.forEach(doc => batch.delete(doc.ref));
+            await batch.commit();
+            const sharesSnap = await db.collection('sharedLists').where('listId', '==', listId).get();
+            const batch2 = db.batch();
+            sharesSnap.forEach(doc => batch2.delete(doc.ref));
+            await batch2.commit();
+        }
+    };
+
     let activeDataManager = lsDataManager; // Padrão inicial para modo LocalStorage
+    let activeListManager = lsListManager;
 
     // ---------------------------------------------------------------------------
     // FUNÇÕES UTILITÁRIAS
@@ -299,9 +376,9 @@ document.addEventListener('DOMContentLoaded', () => {
         const themeToApply = (theme === 'dark' || theme === 'light') ? theme : 'light'; // Garante valor válido
         document.body.classList.add(themeToApply === 'dark' ? 'dark-mode' : 'light-mode');
         
-        if (themeToggleIcon) {
-            themeToggleIcon.className = themeToApply === 'dark' ? 'fas fa-sun' : 'fas fa-moon';
-        }
+        themeToggleIcons.forEach(icon => {
+            if (icon) icon.className = themeToApply === 'dark' ? 'fas fa-sun' : 'fas fa-moon';
+        });
 
         // Salva a preferência de tema
         if (modoOperacao === 'firebase' && currentUser && userProfile) {
@@ -316,10 +393,12 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // Listener para o botão de alternar tema
-    if (themeToggleButton) {
-        themeToggleButton.addEventListener('click', () => {
-            const isDarkMode = document.body.classList.contains('dark-mode');
-            applyTheme(isDarkMode ? 'light' : 'dark');
+    if (themeToggleButtons.length > 0) {
+        themeToggleButtons.forEach(btn => {
+            btn.addEventListener('click', () => {
+                const isDarkMode = document.body.classList.contains('dark-mode');
+                applyTheme(isDarkMode ? 'light' : 'dark');
+            });
         });
     }
 
@@ -355,6 +434,9 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         }
 
+        if(createListButton) createListButton.style.display = 'inline-block';
+        if(backToListsButton) backToListsButton.style.display = 'none';
+
         if(modeIndicator) {
             if (currentUser && userProfile.isPremium) modeIndicator.textContent = 'Premium Cloud';
             else if (currentUser && !userProfile.isPremium) modeIndicator.textContent = 'Gratuito (Online)';
@@ -371,6 +453,7 @@ document.addEventListener('DOMContentLoaded', () => {
      * Observador do estado de autenticação do Firebase.
      * Gerencia a UI e os dados com base no status de login do usuário.
      */
+    let profileInitialized = false;
     auth.onAuthStateChanged(async user => {
         unsubscribePrefsListener(); // Cancela listener de preferências anterior
         unsubscribeItemsListener(); // Cancela listener de itens anterior
@@ -381,27 +464,37 @@ document.addEventListener('DOMContentLoaded', () => {
             // Listener para o perfil do usuário (isPremium, theme)
             unsubscribePrefsListener = db.collection('userProfiles').doc(user.uid)
                 .onSnapshot(async (doc) => {
-                    if (doc.exists) { 
-                        userProfile = doc.data(); 
-                    } else { 
+                    const prevProfile = userProfile;
+                    if (doc.exists) {
+                        userProfile = doc.data();
+                    } else {
                         // Perfil não existe, cria um perfil padrão gratuito
                         userProfile = { isPremium: false, theme: 'light' };
-                        try { 
+                        try {
                             await db.collection('userProfiles').doc(user.uid).set(userProfile);
-                            // console.log("Perfil de usuário gratuito padrão criado no Firestore.");
-                        } catch (e) { 
-                            console.error("Erro ao criar perfil default no Firestore:", e); 
+                        } catch (e) {
+                            console.error("Erro ao criar perfil default no Firestore:", e);
                         }
                     }
-                    // Determina o modo de operação com base no status premium
+
+                    const modeChanged = !prevProfile || prevProfile.isPremium !== userProfile.isPremium;
+
                     modoOperacao = userProfile.isPremium ? 'firebase' : 'localStorage';
                     activeDataManager = userProfile.isPremium ? fbDataManager : lsDataManager;
-                    
-                    applyTheme(userProfile.theme || 'light'); // Aplica tema do perfil ou padrão
-                    updateUIVisibility(true);   // Mostra o conteúdo do app
-                    updateUserSpecificUI();     // Atualiza UI específica do usuário
-                    await loadAndRenderData();  // Carrega e renderiza os dados do modo correto
-                }, 
+
+                    applyTheme(userProfile.theme || 'light');
+
+                    if (!profileInitialized || modeChanged) {
+                        updateUIVisibility(true);
+                        updateUserSpecificUI();
+                        await loadAndRenderLists(true);
+                        await loadAndRenderData();
+                        profileInitialized = true;
+                    } else {
+                        // Apenas atualiza o tema sem mudar de visão
+                        await loadAndRenderLists(false);
+                    }
+                },
                 async (error) => { // Callback de erro para o listener do perfil
                     console.error("Erro no listener do perfil do usuário:", error);
                     // Fallback em caso de erro ao ler o perfil
@@ -411,6 +504,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     applyTheme(localStorage.getItem(LOCAL_STORAGE_THEME_KEY) || 'light');
                     updateUIVisibility(true); 
                     updateUserSpecificUI();
+                    await loadAndRenderLists();
                     await loadAndRenderData();
                 });
         } else { // Usuário está deslogado
@@ -423,8 +517,10 @@ document.addEventListener('DOMContentLoaded', () => {
             updateUIVisibility(false); // Mostra a seção de autenticação
             updateUserSpecificUI();    // Atualiza UI para estado deslogado
             
-            items = []; // Limpa array de itens na memória
-            renderAppUI(); // Limpa a tabela e abas na UI
+            items = [];
+            lists = [];
+            renderLists();
+            renderAppUI();
         }
     });
     
@@ -441,6 +537,7 @@ document.addEventListener('DOMContentLoaded', () => {
             updateUserSpecificUI();   // Atualiza UI para modo convidado
             
             document.body.dataset.appInitialized = "true"; // Marca que o app foi "iniciado" neste modo
+            await loadAndRenderLists();
             await loadAndRenderData(); // Carrega dados do localStorage
         });
     }
@@ -506,6 +603,21 @@ document.addEventListener('DOMContentLoaded', () => {
     /**
      * Carrega os itens (do Firebase ou LocalStorage) e chama a renderização da UI.
      */
+    async function loadAndRenderLists(showListsView = true) {
+        if (modoOperacao === 'firebase' && currentUser) {
+            lists = await fbListManager.loadLists(currentUser.uid);
+        } else {
+            lists = lsListManager.loadLists();
+        }
+        if (lists.length > 0 && !activeListId) activeListId = lists[0].id;
+        renderLists();
+        if (showListsView) {
+            if (listsSection) listsSection.style.display = 'block';
+            if (itemsSection) itemsSection.style.display = 'none';
+            if (backToListsButton) backToListsButton.style.display = 'none';
+        }
+    }
+
     async function loadAndRenderData() {
         unsubscribeItemsListener(); // Limpa listener de itens anterior sempre
 
@@ -513,6 +625,7 @@ document.addEventListener('DOMContentLoaded', () => {
             // Configura o listener em tempo real para itens do Firebase
             unsubscribeItemsListener = db.collection('items')
                 .where('userId', '==', currentUser.uid)
+                .where('listId', '==', activeListId)
                 .orderBy('createdAt', 'desc')
                 .onSnapshot(snapshot => {
                     items = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
@@ -523,7 +636,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     renderAppUI();
                 });
         } else { // Modo LocalStorage (ou deslogado, mas o app não deveria estar visível)
-            items = activeDataManager.loadItems(); // Carrega do localStorage
+            items = activeDataManager.loadItems().filter(it => it.listId === activeListId);
             renderAppUI();
         }
     }
@@ -555,13 +668,14 @@ document.addEventListener('DOMContentLoaded', () => {
     if (itemForm) {
         itemForm.addEventListener('submit', async (e) => {
             e.preventDefault();
-            const newItemData = { 
-                category: categoryInput.value.trim(), 
+            const newItemData = {
+                category: categoryInput.value.trim(),
                 brand: brandInput.value.trim(),
-                name: itemNameInput.value.trim(), 
+                name: itemNameInput.value.trim(),
                 notes: itemNotesInput.value.trim(),
                 rating: parseFloat(hiddenRatingInput.value) || 0,
-                createdAt: new Date()
+                createdAt: new Date(),
+                listId: activeListId
             };
 
             if (!newItemData.name || !newItemData.category || !newItemData.brand) {
@@ -678,7 +792,7 @@ document.addEventListener('DOMContentLoaded', () => {
     async function shareListWithEmail(email, permission) {
         if (!currentUser || !userProfile || !userProfile.isPremium) return;
         try {
-            await db.collection('sharedLists').add({ ownerId: currentUser.uid, invitedEmail: email, permission });
+            await db.collection('sharedLists').add({ ownerId: currentUser.uid, listId: activeListId, invitedEmail: email, permission });
             showInfoModal('Lista compartilhada com sucesso!', true);
         } catch (e) {
             console.error('Erro ao compartilhar lista:', e);
@@ -846,6 +960,84 @@ function updateAutocompleteLists() {
             }
         });
         updateCategoryControls();
+    }
+
+    function renderLists() {
+        if (!listsTableBody) return;
+        listsTableBody.innerHTML = '';
+        if (lists.length === 0) {
+            listsTableBody.innerHTML = '<tr><td colspan="5" class="empty-message">Nenhuma lista encontrada.</td></tr>';
+            return;
+        }
+        lists.forEach(list => {
+            const row = listsTableBody.insertRow();
+            row.dataset.id = list.id;
+            row.insertCell().textContent = list.name || '';
+            row.insertCell().textContent = formatDate(list.createdAt);
+            row.insertCell().textContent = formatDate(list.updatedAt);
+            row.insertCell().textContent = (currentUser && list.ownerId === currentUser.uid) ? 'Você' : (list.ownerEmail || '');
+            const actionsCell = row.insertCell();
+            const editBtn = document.createElement('button');
+            editBtn.className = 'edit-btn';
+            editBtn.innerHTML = '<i class="fas fa-edit"></i> Editar';
+            editBtn.addEventListener('click', () => openList(list.id));
+            actionsCell.appendChild(editBtn);
+            const shareBtn = document.createElement('button');
+            shareBtn.className = 'share-btn';
+            shareBtn.innerHTML = '<i class="fas fa-share-alt"></i>';
+            shareBtn.addEventListener('click', () => { activeListId = list.id; shareModal.classList.add('show'); });
+            actionsCell.appendChild(shareBtn);
+            const delBtn = document.createElement('button');
+            delBtn.className = 'delete-btn';
+            delBtn.innerHTML = '<i class="fas fa-trash"></i>';
+            delBtn.addEventListener('click', () => confirmDeleteList(list.id));
+            actionsCell.appendChild(delBtn);
+        });
+    }
+
+    function openList(id) {
+        activeListId = id;
+        if (listNameDisplay) {
+            const l = lists.find(li => li.id === id);
+            if (l) listNameDisplay.textContent = l.name;
+        }
+        if (listsSection) listsSection.style.display = 'none';
+        if (itemsSection) itemsSection.style.display = 'block';
+        if (backToListsButton) backToListsButton.style.display = 'inline-block';
+        loadAndRenderData();
+    }
+
+    function backToListsView() {
+        if (itemsSection) itemsSection.style.display = 'none';
+        if (listsSection) listsSection.style.display = 'block';
+        if (backToListsButton) backToListsButton.style.display = 'none';
+    }
+
+    function confirmDeleteList(id) {
+        const l = lists.find(li => li.id === id);
+        showConfirmationModal(`Excluir a lista "${l ? l.name : ''}" e todos os itens?`, async () => {
+            if (modoOperacao === 'firebase' && currentUser) {
+                await fbListManager.deleteList(id);
+            } else {
+                items = items.filter(it => it.listId !== id);
+                lsDataManager.saveItems(items);
+            }
+
+            // Remove a lista do array local em ambos os modos
+            lists = lists.filter(li => li.id !== id);
+            if (modoOperacao !== 'firebase') lsListManager.saveLists(lists);
+
+            if (activeListId === id) {
+                activeListId = lists.length ? lists[0].id : null;
+            }
+            renderLists();
+        }, true);
+    }
+
+    function formatDate(ts) {
+        if (!ts) return '';
+        const d = ts.toDate ? ts.toDate() : (ts instanceof Date ? ts : new Date(ts));
+        return d.toLocaleDateString();
     }
 
     // ---------------------------------------------------------------------------
@@ -1021,6 +1213,58 @@ function updateAutocompleteLists() {
                 shareRecordingCheckbox.checked = false;
                 shareModal.classList.add('show');
             }
+        });
+    }
+
+    if (backToListsButton) {
+        backToListsButton.addEventListener('click', () => {
+            backToListsView();
+        });
+    }
+
+    if (createListButton && createListModal && createListForm) {
+        createListButton.addEventListener('click', () => {
+            if (newListNameInput) newListNameInput.value = '';
+            createListModal.classList.add('show');
+        });
+
+        createListCancel.addEventListener('click', () => {
+            createListModal.classList.remove('show');
+        });
+
+        createListForm.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const name = newListNameInput.value.trim();
+            if (!name) return;
+            if (modoOperacao === 'firebase' && currentUser) {
+                const newList = await fbListManager.addList(currentUser.uid, name);
+                lists.unshift(newList);
+            } else {
+                const newList = { id: generateId(), name, createdAt: new Date(), updatedAt: new Date(), ownerId: null };
+                lists.unshift(newList);
+                lsListManager.saveLists(lists);
+            }
+            renderLists();
+            createListModal.classList.remove('show');
+        });
+
+        createListModal.addEventListener('click', (e) => {
+            if (e.target === createListModal) createListModal.classList.remove('show');
+        });
+    }
+
+    if (listNameDisplay) {
+        listNameDisplay.addEventListener('blur', async () => {
+            const newName = listNameDisplay.textContent.trim();
+            const list = lists.find(l => l.id === activeListId);
+            if (!list || !newName) return;
+            list.name = newName;
+            if (modoOperacao === 'firebase' && currentUser) {
+                await fbListManager.updateList(activeListId, { name: newName });
+            } else {
+                lsListManager.saveLists(lists);
+            }
+            renderLists();
         });
     }
 

--- a/style.css
+++ b/style.css
@@ -1541,6 +1541,73 @@ body.dark-mode #items-table tbody tr:nth-child(even) {
     opacity: 0.85;
 }
 
+/* Estilos para a tabela de listas */
+#lists-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 20px;
+    font-size: 0.9em;
+}
+
+#lists-table th,
+#lists-table td {
+    border: 1px solid var(--border-color);
+    padding: 10px 8px;
+    font-size: 0.85em;
+    text-align: left;
+    vertical-align: middle;
+}
+
+body.dark-mode #lists-table th,
+body.dark-mode #lists-table td {
+    border: 1px solid var(--border-color-dark);
+}
+
+#lists-table thead th {
+    background-color: var(--text-color-dark);
+    font-weight: 700;
+    text-transform: uppercase;
+    font-size: 0.85em;
+    letter-spacing: 0.5px;
+    color: var(--text-secondary-color);
+}
+
+body.light-mode #lists-table thead th {
+    background-color: var(--text-color-dark);
+    color: var(--text-secondary-color);
+}
+
+body.dark-mode #lists-table thead th {
+    background-color: #2c323f;
+    color: var(--text-secondary-color-dark);
+}
+
+#lists-table tbody tr:nth-child(even) {
+    background-color: #f8f9fa;
+}
+
+body.dark-mode #lists-table tbody tr:nth-child(even) {
+    background-color: #282d37;
+}
+
+#lists-table td button {
+    margin-right: 5px;
+    padding: 6px 10px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9em;
+    color: #fff;
+    transition: opacity 0.2s;
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+}
+
+#lists-table td button:hover {
+    opacity: 0.85;
+}
+
 .edit-btn {
     background-color: var(--warning-color);
     color: #333;
@@ -1563,6 +1630,15 @@ body.dark-mode .delete-btn {
 .save-btn {
     background-color: var(--success-color);
     color: #fff;
+}
+
+.share-btn {
+    background-color: var(--success-color);
+    color: #fff;
+}
+
+body.dark-mode .share-btn {
+    background-color: var(--success-color-dark);
 }
 
 body.dark-mode .save-btn {


### PR DESCRIPTION
## Summary
- create list management table and renameable list title
- allow switching between lists and items sections
- manage lists in Firebase and localStorage
- update Firestore rules for lists support
- add modal for creating lists and keep theme toggle visible
- document Firebase migration steps
- **fix**: update Firestore rules for lists
- fix list deletion reloading lists and improve theme handling
- preserve current page when changing theme and recolor share button
- support dark theme colors for lists table

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685061f50a1c8325a503942725a33c50