### PR TITLE
Add toast notifications for list changes

### DIFF
--- a/script-app.js
+++ b/script-app.js
@@ -764,6 +764,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 if(currentRatingDisplay) currentRatingDisplay.textContent = '0.0';
                 if(formStarRatingContainer) createStars(formStarRatingContainer, 0, true, hiddenRatingInput, currentRatingDisplay);
                 if(categoryInput) categoryInput.focus();
+                showToast('Item adicionado com sucesso!');
             } catch (error) {
                 console.error("Erro ao adicionar item:", error);
                 showInfoModal('Erro ao adicionar item. Tente novamente.');
@@ -820,7 +821,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!itemToDelete) return;
 
         try {
-            if (modoOperacao === 'firebase' && currentUser) { 
+            if (modoOperacao === 'firebase' && currentUser) {
                 if (!activeListCanWrite) { showInfoModal('Acesso somente leitura.'); return; }
                 await activeDataManager.deleteItem(itemId); // onSnapshot do Firebase cuida da UI
                 // A lógica de atualizar activeCategory se a categoria for removida pode ser feita no callback do onSnapshot
@@ -833,6 +834,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
                 renderAppUI(); // Re-renderiza para LocalStorage
             }
+            showToast('Item excluído com sucesso!', true);
         } catch (error) {
             console.error("Erro ao excluir item:", error);
             showInfoModal('Erro ao excluir item.');
@@ -1178,7 +1180,8 @@ function updateAutocompleteLists() {
                 activeListId = lists.length ? lists[0].id : null;
             }
             renderLists();
-        }, true);
+            showToast('Lista excluída com sucesso!', true);
+        });
     }
 
     function formatDate(ts) {
@@ -1232,25 +1235,31 @@ function updateAutocompleteLists() {
      * @param {string} message - Mensagem a ser exibida.
      * @param {boolean} positive - Se verdadeiro, aplica estilo de ação positiva ao botão.
      */
-    function showInfoModal(message, positive = false) {
+    function showInfoModal(message, positive = false, danger = false) {
         if (!confirmationModal || !modalMessage || !modalConfirmBtn) {
             alert(message);
             return;
         }
         const originalText = modalConfirmBtn.textContent;
         const hadPositive = modalConfirmBtn.classList.contains('positive-action');
+        const hadDanger = confirmationModal.classList.contains('modal-danger');
         modalMessage.textContent = message;
         if(modalIcon) {
-            modalIcon.className = 'modal-icon ' + (positive ? 'fas fa-check-circle' : 'fas fa-info-circle');
+            let iconClass = 'fas fa-info-circle';
+            if (positive) iconClass = 'fas fa-check-circle';
+            else if (danger) iconClass = 'fas fa-exclamation-circle';
+            modalIcon.className = 'modal-icon ' + iconClass;
         }
         modalConfirmBtn.textContent = 'OK';
         modalConfirmBtn.classList.toggle('positive-action', positive);
+        confirmationModal.classList.toggle('modal-danger', danger);
         if (modalCancelBtn) modalCancelBtn.style.display = 'none';
         actionToConfirm = null;
         confirmationModal.classList.add('show');
         const cleanup = () => {
             modalConfirmBtn.textContent = originalText;
             modalConfirmBtn.classList.toggle('positive-action', hadPositive);
+            confirmationModal.classList.toggle('modal-danger', hadDanger);
             if (modalCancelBtn) modalCancelBtn.style.display = '';
         };
         modalConfirmBtn.addEventListener('click', cleanup, { once: true });
@@ -1408,6 +1417,7 @@ function updateAutocompleteLists() {
             }
             renderLists();
             createListModal.classList.remove('show');
+            showToast('Lista adicionada com sucesso!');
         });
 
         createListModal.addEventListener('click', (e) => {
@@ -1415,9 +1425,9 @@ function updateAutocompleteLists() {
         });
     }
 
-    function showToast(message) {
+    function showToast(message, danger = false) {
         const toast = document.createElement('div');
-        toast.className = 'toast-message';
+        toast.className = 'toast-message' + (danger ? ' toast-danger' : '');
         toast.textContent = message;
         document.body.appendChild(toast);
         requestAnimationFrame(() => toast.classList.add('show'));

--- a/style.css
+++ b/style.css
@@ -1974,6 +1974,22 @@ body.dark-mode .modal-content {
     margin-bottom: 10px;
 }
 
+.modal-danger .modal-icon {
+    color: var(--danger-color);
+}
+
+body.dark-mode .modal-danger .modal-icon {
+    color: var(--danger-color-dark);
+}
+
+.modal-danger #modal-message {
+    color: var(--danger-color);
+}
+
+body.dark-mode .modal-danger #modal-message {
+    color: var(--danger-color-dark);
+}
+
 .modal-content button {
     padding: 10px 20px;
     border: none;
@@ -2189,6 +2205,18 @@ body.dark-mode .switch input:checked+.slider-toggle {
     transform: translateY(20px);
     transition: opacity 0.3s, transform 0.3s;
     z-index: 1100;
+}
+
+.toast-message.toast-danger {
+    background-color: #f8d7da;
+    color: var(--danger-color);
+    border-color: var(--danger-color);
+}
+
+body.dark-mode .toast-message.toast-danger {
+    background-color: #5f1b1b;
+    color: var(--danger-color-dark);
+    border-color: var(--danger-color-dark);
 }
 
 .toast-message.show {


### PR DESCRIPTION
## Summary
- show toast when adding and deleting lists or items
- style a `toast-danger` type for deletion warnings
- allow `showToast` to support danger styling

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68517e79a8c88325a9f3b8e29e65fbd7