### PR TITLE
Refactor Cypress tests with page objects

### DIFF
--- a/cypress/e2e/app.cy.js
+++ b/cypress/e2e/app.cy.js
@@ -5,7 +5,6 @@ class LoginForm {
     passwordInput: () => cy.get('#login-password'),
     submitBtn:    () => cy.get('#login-form .btn-auth')
   };
-
   typeUsername(text) { if (text) this.elements.usernameInput().type(text); }
   typePassword(text) { if (text) this.elements.passwordInput().type(text); }
   clickSubmit()      { this.elements.submitBtn().click(); }
@@ -21,12 +20,11 @@ class ItemForm {
     rating:   () => cy.get('#form-star-rating'),
     submit:   () => cy.get('#item-form button[type="submit"]')
   };
-  fillItem({cat, brand, name, notes, rating}) {
+  fillItem({cat, brand, name, notes}) {
     if (cat)   this.elements.category().type(cat);
     if (brand) this.elements.brand().type(brand);
     if (name)  this.elements.name().type(name);
     if (notes) this.elements.notes().type(notes);
-    // rating could be set with custom commands
   }
   submit() { this.elements.submit().click(); }
 }
@@ -34,85 +32,139 @@ class ItemForm {
 // RegisterForm.js
 class RegisterForm {
   elements = {
-    usernameInput: () => cy.get('#login-email'),
-    passwordInput: () => cy.get('#login-password'),
-    newusernameInput: () => cy.get('#signup-email'),
-    newpasswordInput: () => cy.get('#signup-password'),
-    submitBtn: () => cy.get('#btn-auth'),
+    usernameInput:   () => cy.get('#login-email'),
+    passwordInput:   () => cy.get('#login-password'),
+    newusernameInput:() => cy.get('#signup-email'),
+    newpasswordInput:() => cy.get('#signup-password'),
+    submitBtn:       () => cy.get('#btn-auth'),
     registrationBtn: () => cy.get('#show-signup'),
-    createUserBtn: () => cy.get('#submit-new-user')
-  }
-
-  typeUsername(text) {
-    if(!text) return;
-    this.elements.usernameInput().type(text)
-  }
-
-  typePassword(text) {
-    if(!text) return;
-    this.elements.passwordInput().type(text)
-  }
-
-  typeNewUsername(text) {
-    if(!text) return;
-    this.elements.newusernameInput().type(text)
-  }
-
-  typeNewPassword(text) {
-    if(!text) return;
-    this.elements.newpasswordInput().type(text)
-  }
-  clickSubmit(){
-    this.elements.submitBtn().click()
-  }
-  
-  clickRegister(){
-    this.elements.registrationBtn().click()
-  }  
-  
-  clickCreateUser(){
-    this.elements.createUserBtn().click()
-  }
-  
+    createUserBtn:   () => cy.get('#submit-new-user')
+  };
+  typeUsername(text)      { if (text) this.elements.usernameInput().type(text); }
+  typePassword(text)      { if (text) this.elements.passwordInput().type(text); }
+  typeNewUsername(text)   { if (text) this.elements.newusernameInput().type(text); }
+  typeNewPassword(text)   { if (text) this.elements.newpasswordInput().type(text); }
+  clickSubmit()           { this.elements.submitBtn().click(); }
+  clickRegister()         { this.elements.registrationBtn().click(); }
+  clickCreateUser()       { this.elements.createUserBtn().click(); }
 }
 
-const registerForm = new RegisterForm()
-const loginForm = new LoginForm()
-const itemForm = new ItemForm()
+// ListsPage.js
+class ListsPage {
+  elements = {
+    createBtn:      () => cy.get('#create-list'),
+    newNameInput:   () => cy.get('#new-list-name'),
+    saveNewBtn:     () => cy.get('#create-list-save'),
+    listRow:        (name) => cy.contains('#lists-table tr', name),
+    deleteBtnFor:   (name) => this.elements.listRow(name).find('.delete-btn'),
+    confirmDelete:  () => cy.get('#modal-confirm-btn')
+  };
+  createList(name) {
+    this.elements.createBtn().click();
+    this.elements.newNameInput().type(name);
+    this.elements.saveNewBtn().click();
+  }
+  deleteList(name) {
+    this.elements.deleteBtnFor(name).click();
+    this.elements.confirmDelete().click();
+  }
+}
+
+// ItemsPage.js
+class ItemsPage {
+  elements = {
+    editBtn:   (name) => cy.contains('#items-table tr', name).find('.edit-btn'),
+    deleteBtn: (name) => cy.contains('#items-table tr', name).find('.delete-btn'),
+    editInput: (field) => cy.get(`.editable-input[data-field="${field}"]`),
+    saveBtn:   () => cy.get('.save-btn'),
+    confirmDelete: () => cy.get('#modal-confirm-btn')
+  };
+  editItem(name, newName) {
+    this.elements.editBtn(name).click();
+    this.elements.editInput('name').clear().type(newName);
+    this.elements.saveBtn().click();
+  }
+  deleteItem(name) {
+    this.elements.deleteBtn(name).click();
+    this.elements.confirmDelete().click();
+  }
+}
+
+// ThemeToggle.js
+class ThemeToggle {
+  elements = { toggle: () => cy.get('#theme-toggle') };
+  toggle() { this.elements.toggle().click(); }
+}
+
+// ImportExportPage.js
+class ImportExportPage {
+  elements = {
+    exportBtn: () => cy.get('#export-data'),
+    importInput: () => cy.get('#import-file'),
+    confirmBtn: () => cy.get('#modal-confirm-btn')
+  };
+  exportData() { this.elements.exportBtn().click(); }
+  importData(file) {
+    this.elements.importInput().selectFile(file, { force: true });
+    this.elements.confirmBtn().click();
+  }
+}
+
+// SharePage.js
+class SharePage {
+  elements = {
+    openBtn:  () => cy.get('#share-list'),
+    email:    () => cy.get('#share-email'),
+    writeChk: () => cy.get('#share-recording'),
+    saveBtn:  () => cy.get('#share-save-btn'),
+    userEntry: (email, perm) => cy.contains('#shared-users-list li', `${email} - ${perm}`)
+  };
+  share(email, write = false) {
+    this.elements.openBtn().click();
+    this.elements.email().type(email);
+    if (write) this.elements.writeChk().check();
+    this.elements.saveBtn().click();
+  }
+}
+
+const registerForm = new RegisterForm();
+const loginForm    = new LoginForm();
+const itemForm     = new ItemForm();
+const listsPage    = new ListsPage();
+const itemsPage    = new ItemsPage();
+const themeToggle  = new ThemeToggle();
+const importExport = new ImportExportPage();
+const sharePage    = new SharePage();
+
+// Tests
 
 describe('Access Main Site', () => {
   it('passes', () => {
-    cy.visit('/')
-  })
-});
-describe('User Authentication', () => {
-  describe('Registering a new user', () => {
-    const input = {
-      user: 'registered@test.com',
-      password: 'Password123'
-    }
-    it(`Given I am on the registration form`, () => {
-      cy.visit('/app.html'),
-      registerForm.clickRegister()
-    }),
-
-    it(`When I fill "${input.user}" with a valid email`, () => {
-      registerForm.typeNewUsername(input.user)
-    }),
-
-    it(`And I fill "${input.password}" with a valid password`, () => {
-      registerForm.typeNewPassword(input.password)
-    }),
-
-    it(`And I submit the "signup-form"`, () => {
-      registerForm.clickCreateUser()
-    }),
-
-    it(`Then I should see the main screen with my lists`, () => {
-
-    })
+    cy.visit('/');
   });
 });
+
+describe('User Authentication', () => {
+  describe('Registering a new user', () => {
+    const input = { user: 'registered@test.com', password: 'Password123' };
+    it('Given I am on the registration form', () => {
+      cy.visit('/app.html');
+      registerForm.clickRegister();
+    });
+    it(`When I fill "${input.user}" with a valid email`, () => {
+      registerForm.typeNewUsername(input.user);
+    });
+    it(`And I fill "${input.password}" with a valid password`, () => {
+      registerForm.typeNewPassword(input.password);
+    });
+    it('And I submit the "signup-form"', () => {
+      registerForm.clickCreateUser();
+    });
+    it('Then I should see the main screen with my lists', () => {
+      cy.get('#lists-section').should('be.visible');
+    });
+  });
+
   describe('Logging in with an existing user', () => {
     it('Given I am on the login form', () => {
       cy.visit('/app.html');
@@ -141,80 +193,63 @@ describe('User Authentication', () => {
       cy.get('#auth-section').should('be.visible');
     });
   });
-
+});
 
 describe('List Management', () => {
+  const listName = 'Nova Lista';
   it('creates a new list', () => {
-    cy.get('#create-list').click();
-    cy.get('#new-list-name').type('Nova Lista');
-    cy.get('#create-list-save').click();
-    cy.contains('#lists-table td', 'Nova Lista').should('exist');
+    listsPage.createList(listName);
+    cy.contains('#lists-table td', listName).should('exist');
   });
-
   it('deletes a list', () => {
-    cy.contains('#lists-table tr', 'Nova Lista')
-      .find('.delete-btn')
-      .click();
-    cy.get('#modal-confirm-btn').click();
-    cy.contains('#lists-table td', 'Nova Lista').should('not.exist');
+    listsPage.deleteList(listName);
+    cy.contains('#lists-table td', listName).should('not.exist');
   });
 });
 
 describe('Item Management', () => {
+  const itemName = 'Galaxy S23';
   it('adds a new item', () => {
     itemForm.fillItem({
       cat: 'Eletrônicos',
       brand: 'Samsung',
-      name: 'Galaxy S23',
+      name: itemName,
       notes: 'telefone de teste'
     });
     itemForm.submit();
-    cy.contains('#items-table td', 'Galaxy S23').should('exist');
+    cy.contains('#items-table td', itemName).should('exist');
   });
-
   it('edits an item', () => {
-    cy.contains('#items-table tr', 'Galaxy S23')
-      .find('.edit-btn')
-      .click();
-    cy.get('.editable-input[data-field="name"]').clear().type('Galaxy Edit');
-    cy.get('.save-btn').click();
+    itemsPage.editItem(itemName, 'Galaxy Edit');
     cy.contains('#items-table td', 'Galaxy Edit').should('exist');
   });
-
   it('deletes an item', () => {
-    cy.contains('#items-table tr', 'Galaxy Edit')
-      .find('.delete-btn')
-      .click();
-    cy.get('#modal-confirm-btn').click();
+    itemsPage.deleteItem('Galaxy Edit');
     cy.contains('#items-table td', 'Galaxy Edit').should('not.exist');
   });
 });
 
 describe('Theme Preference', () => {
   it('toggles dark mode', () => {
-    cy.get('#theme-toggle').click();
+    themeToggle.toggle();
     cy.get('body').should('have.class', 'dark-mode');
   });
 });
 
 describe('Import and Export', () => {
   it('exports data to JSON', () => {
-    cy.get('#export-data').click();
+    importExport.exportData();
     // Add assertion for downloaded file if needed
   });
-
   it('imports items from JSON', () => {
-    cy.get('#import-file').selectFile('cypress/fixtures/sample-data.json', { force: true });
-    cy.get('#modal-confirm-btn').click();
+    importExport.importData('cypress/fixtures/sample-data.json');
     // Verify imported data in table
   });
 });
 
 describe('List Sharing (Premium)', () => {
   it('shares a list with read permission', () => {
-    cy.get('#share-list').click();
-    cy.get('#share-email').type('other@example.com');
-    cy.get('#share-save-btn').click();
-    cy.contains('#shared-users-list li', 'other@example.com - read').should('exist');
+    sharePage.share('other@example.com');
+    sharePage.elements.userEntry('other@example.com', 'read').should('exist');
   });
 });


### PR DESCRIPTION
## Summary
- refactor cypress tests to use page objects for login, registration, lists, items and other features

## Testing
- `npm test` *(fails: 403 Forbidden when trying to download cypress)*

------
https://chatgpt.com/codex/tasks/task_e_6852f0b5cd4483258580626861bcc75f