### PR TITLE
Fix listName variable scope for Cypress tests

### DIFF
--- a/cypress/e2e/app.cy.js
+++ b/cypress/e2e/app.cy.js
@@ -145,6 +145,7 @@ describe('Access Main Site', () => {
 });
 
 describe('Not Authenticated User', () => {
+  const listName = 'Nova Lista';
   describe('Access without login', () => {
     it('I can access guest mode', () => {
       cy.visit('/app.html');
@@ -163,7 +164,6 @@ describe('Not Authenticated User', () => {
     });
   });
   describe('List Management', () => {
-    const listName = 'Nova Lista';
     it('Access without login', () => {
       cy.visit('/app.html');
       cy.get('#continue-guest').click();


### PR DESCRIPTION
## Summary
- move `listName` to the top of the `Not Authenticated User` suite so it can be used across tests

## Testing
- `npm test` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68541fea2e3c8325aa5a87cf8066b83d