### PR TITLE
Fix header controls layout

### DIFF
--- a/app.html
+++ b/app.html
@@ -123,18 +123,6 @@
                   <i class="fas fa-moon"></i>
                 </button>
                 <button id="create-list"><i class="fas fa-plus"></i> Criar Lista</button>
-                <button id="export-data-lists">
-                  <i class="fas fa-file-export"></i>Exportar Dados
-                </button>
-                <label for="import-file-lists" class="button-import-label">
-                  <i class="fas fa-file-import"></i>Importar Dados
-                </label>
-                <input
-                  type="file"
-                  id="import-file-lists"
-                  accept=".json"
-                  style="display: none"
-                />
                 <button id="upgrade-to-premium-lists" class="btn btn-premium-cta upgrade-to-premium" style="display: none">
                   <i class="fas fa-star"></i> Fazer Upgrade para Premium
                 </button>

--- a/style.css
+++ b/style.css
@@ -897,6 +897,12 @@ body.dark-mode #app-content .container {
     color: var(--primary-color);
 }
 
+.controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
 .controls button:hover,
 .controls .button-import-label:hover {
     background-color: var(--primary-color);


### PR DESCRIPTION
## Summary
- revert header styles to use `inline-flex` buttons
- add `.controls` flex layout near line 900
- keep import/export buttons removed from list screen

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856a864d760832584840a26a0a870d1