### PR TITLE
Fix deletion of shared list records

### DIFF
--- a/script-app.js
+++ b/script-app.js
@@ -322,7 +322,10 @@ document.addEventListener('DOMContentLoaded', () => {
             itemsSnap.forEach(doc => batch.delete(doc.ref));
             await batch.commit();
 
-            const sharesSnap = await db.collection('sharedLists').where('listId', '==', listId).get();
+            const sharesSnap = await db.collection('sharedLists')
+                .where('listId', '==', listId)
+                .where('ownerId', '==', currentUser.uid)
+                .get();
             const batch2 = db.batch();
             sharesSnap.forEach(doc => batch2.delete(doc.ref));
             await batch2.commit();


### PR DESCRIPTION
## Summary
- ensure user only deletes shared list documents they own

## Testing
- `npm test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6865c10810488325a7564aa156eb311e