### PR TITLE
Fix Firebase listener error when deleting lists

### DIFF
--- a/script-app.js
+++ b/script-app.js
@@ -1229,7 +1229,18 @@ function updateAutocompleteLists() {
                 if (modoOperacao !== 'firebase') lsListManager.saveLists(lists);
 
                 if (activeListId === id) {
-                    activeListId = lists.length ? lists[0].id : null;
+                    unsubscribeItemsListener();
+                    if (lists.length) {
+                        const nextList = lists[0];
+                        activeListId = nextList.id;
+                        activeListOwnerId = nextList.ownerId || (currentUser ? currentUser.uid : null);
+                        activeListCanWrite = nextList.canWrite !== undefined ? nextList.canWrite : true;
+                    } else {
+                        activeListId = null;
+                        activeListOwnerId = null;
+                        activeListCanWrite = true;
+                    }
+                    await loadAndRenderData();
                 }
                 renderLists();
                 showToast('Lista excluída com sucesso!', true);


### PR DESCRIPTION
## Summary
- stop and reset item listener when a list is removed
- reload items so listener queries the next available list

## Testing
- `npm test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6865c871369883259992e196d09a1263